### PR TITLE
implements QuasiQuoters

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,6 +30,7 @@ library:
     - path
     - exceptions
     - filepath
+    - template-haskell
 
 tests:
   strong-path-test:

--- a/src/StrongPath/Internal.hs
+++ b/src/StrongPath/Internal.hs
@@ -1,11 +1,14 @@
+{-# LANGUAGE DeriveLift #-}
+
 module StrongPath.Internal where
 
-import           Control.Monad.Catch     (MonadThrow)
-import qualified Path                    as P
-import qualified Path.Posix              as PP
-import qualified Path.Windows            as PW
-import qualified System.FilePath.Posix   as FPP
-import qualified System.FilePath.Windows as FPW
+import           Control.Monad.Catch        (MonadThrow)
+import           Language.Haskell.TH.Syntax (Lift)
+import qualified Path                       as P
+import qualified Path.Posix                 as PP
+import qualified Path.Windows               as PW
+import qualified System.FilePath.Posix      as FPP
+import qualified System.FilePath.Windows    as FPW
 
 
 -- | s -> standard, b -> base, t -> type
@@ -25,24 +28,25 @@ data Path s b t
     | RelFileP (PP.Path PP.Rel PP.File) RelPathPrefix
     | AbsDirP  (PP.Path PP.Abs PP.Dir)
     | AbsFileP (PP.Path PP.Abs PP.File)
-    deriving (Show, Eq)
+    deriving (Show, Eq, Lift)
 
 data RelPathPrefix = ParentDir Int -- ^ ../, Int saying how many times it repeats.
                    | NoPrefix
-    deriving (Show, Eq)
+    deriving (Show, Eq, Lift)
 
 -- | base
-data Abs
-data Rel dir
+data Abs deriving Lift
+data Rel dir deriving Lift
 
 -- | type
-data Dir dir
-data File file
+data Dir dir deriving Lift
+data File file deriving Lift
 
 -- | standard
 data System -- Depends on the platform, it is either Posix or Windows.
-data Windows
-data Posix
+  deriving Lift
+data Windows deriving Lift
+data Posix deriving Lift
 
 type Path' = Path System
 type Rel' = Rel ()

--- a/src/StrongPathQQ.hs
+++ b/src/StrongPathQQ.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module StrongPathQQ
+  ( absdir, absdirP, absdirW
+  , absfile, absfileP, absfileW
+  , reldir, reldirP, reldirW
+  , relfile, relfileP, relfileW
+  ) where
+
+import Language.Haskell.TH.Quote  (QuasiQuoter(..))
+import Language.Haskell.TH.Syntax (Lift(..))
+
+import qualified Path         as P
+import qualified Path.Posix   as PP
+import qualified Path.Windows as PW
+
+import StrongPath
+
+qq :: (Lift t, Show err)
+   => (res -> t) -> (String -> Either err res) -> QuasiQuoter
+qq from parse = QuasiQuoter
+    { quoteExp  = either (error . show) (lift . from) . parse
+    , quotePat  = err "pattern"
+    , quoteType = err "type"
+    , quoteDec  = err "declaration"
+    }
+  where
+    err what x = fail ("unexpected " ++ what ++ ", must be expression: " ++ x)
+
+absdir, absdirP, absdirW :: QuasiQuoter
+absdir  = qq fromPathAbsDir  P.parseAbsDir
+absdirP = qq fromPathAbsDirP PP.parseAbsDir
+absdirW = qq fromPathAbsDirW PW.parseAbsDir
+
+absfile, absfileP, absfileW :: QuasiQuoter
+absfile  = qq fromPathAbsFile  P.parseAbsFile
+absfileP = qq fromPathAbsFileP PP.parseAbsFile
+absfileW = qq fromPathAbsFileW PW.parseAbsFile
+
+reldir, reldirP, reldirW :: QuasiQuoter
+reldir  = qq fromPathRelDir  P.parseRelDir
+reldirP = qq fromPathRelDirP PP.parseRelDir
+reldirW = qq fromPathRelDirW PW.parseRelDir
+
+relfile, relfileP, relfileW :: QuasiQuoter
+relfile  = qq fromPathRelFile  P.parseRelFile
+relfileP = qq fromPathRelFileP PP.parseRelFile
+relfileW = qq fromPathRelFileW PW.parseRelFile

--- a/strong-path.cabal
+++ b/strong-path.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4e32ddb6e7ec4cde61c94e973a0a471cb14ad1767946775b0fb93228a8ff8447
+-- hash: 479636ea881f78a2bb8de38a260dc2c9674c7edfda5dedffb3c5ba23128751bd
 
 name:           strong-path
 version:        0.1.0.0
@@ -30,6 +30,7 @@ source-repository head
 library
   exposed-modules:
       StrongPath
+      StrongPathQQ
       StrongPath.Internal
   other-modules:
       Paths_strong_path
@@ -41,6 +42,7 @@ library
     , exceptions
     , filepath
     , path
+    , template-haskell
   default-language: Haskell2010
 
 test-suite strong-path-test


### PR DESCRIPTION
This is an implementation of the quasiquoters, for example these should now be identical:

    λ fromPathRelDirP [PP.reldir|some/dir/|]
    RelDirP "some/dir/" NoPrefix
    λ [reldirP|some/dir/|]
    RelDirP "some/dir/" NoPrefix

It implements:

    absdir, absdirP, absdirW :: QuasiQuoter
    absfile, absfileP, absfileW :: QuasiQuoter
    reldir, reldirP, reldirW :: QuasiQuoter
    relfile, relfileP, relfileW :: QuasiQuoter

