### PR TITLE
Add hashable instance for StrongPath (#43)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ library:
     - exceptions >=0.10 && <0.11
     - filepath >=1.4 && <1.5
     - template-haskell >=2.16 && <2.18
+    - hashable >=1.3 && < 1.4
 
 tests:
   strong-path-test:
@@ -49,6 +50,7 @@ tests:
       - strong-path
       - path
       - filepath
+      - hashable >=1.3 && < 1.4
       - tasty >=1.4 && <1.5
       - tasty-hspec >=1.1 && <1.3
       - tasty-quickcheck >=0.10 && <0.11

--- a/src/StrongPath.hs
+++ b/src/StrongPath.hs
@@ -270,6 +270,7 @@ module StrongPath
 where
 
 import StrongPath.FilePath
+import StrongPath.Instances ()
 import StrongPath.Operations
 import StrongPath.TH
 import StrongPath.Types

--- a/src/StrongPath/Instances.hs
+++ b/src/StrongPath/Instances.hs
@@ -1,0 +1,15 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module StrongPath.Instances where
+
+import Data.Hashable
+import StrongPath.FilePath
+import StrongPath.Types
+
+-- Hashable instance for Path declared here, as an orphaned instance, instead of
+-- in StronPath.Internal to avoid cyclic dependency between StrongPath.FilePath
+-- and StrongPath.Internal. (This cycle would arise due to the use of
+-- `toFilePath` from FilePath in the instance declaration and the dependency of
+-- the FilePath module on the types from the Internal module)
+instance Hashable (Path s b t) where
+  hashWithSalt salt = hashWithSalt salt . toFilePath

--- a/src/StrongPath/Instances.hs
+++ b/src/StrongPath/Instances.hs
@@ -11,5 +11,10 @@ import StrongPath.Types
 -- and StrongPath.Internal. (This cycle would arise due to the use of
 -- `toFilePath` from FilePath in the instance declaration and the dependency of
 -- the FilePath module on the types from the Internal module)
+
+-- |
+-- Caveat: For two relative Paths, that only differ in the Directory, that they
+-- are relative to, this Hashable instance will return the same hash even though
+-- they are different paths.
 instance Hashable (Path s b t) where
   hashWithSalt salt = hashWithSalt salt . toFilePath

--- a/strong-path.cabal
+++ b/strong-path.cabal
@@ -31,6 +31,7 @@ library
   exposed-modules:
       StrongPath
       StrongPath.FilePath
+      StrongPath.Instances
       StrongPath.Internal
       StrongPath.Operations
       StrongPath.Path
@@ -45,6 +46,7 @@ library
       base >=4.7 && <5
     , exceptions ==0.10.*
     , filepath ==1.4.*
+    , hashable ==1.3.*
     , path >=0.9.2 && <0.10
     , template-haskell >=2.16 && <2.18
   default-language: Haskell2010
@@ -55,6 +57,7 @@ test-suite strong-path-test
   other-modules:
       PathTest
       StrongPath.FilePathTest
+      StrongPath.InstanceTest
       StrongPath.InternalTest
       StrongPath.PathTest
       StrongPath.THTest
@@ -67,6 +70,7 @@ test-suite strong-path-test
   build-depends:
       base >=4.7 && <5
     , filepath
+    , hashable ==1.3.*
     , hspec >=2.7 && <2.10
     , path
     , strong-path

--- a/test/StrongPath/InstanceTest.hs
+++ b/test/StrongPath/InstanceTest.hs
@@ -9,6 +9,6 @@ import Test.Tasty.Hspec (testSpec)
 test_StrongPathInstance :: IO TestTree
 test_StrongPathInstance = testSpec "StrongPath.Instance" $ do
   it "Hashable returns hash of underlying filepath" $ do
-    let rawPath = "/abPath/dir/"
-    path <- parseAbsDir rawPath
+    let rawPath = "relPath/dir/"
+    path <- parseRelDir rawPath
     hash rawPath `shouldBe` hash path

--- a/test/StrongPath/InstanceTest.hs
+++ b/test/StrongPath/InstanceTest.hs
@@ -1,0 +1,14 @@
+module StrongPath.InstanceTest where
+
+import Data.Hashable
+import StrongPath
+import Test.Hspec
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec (testSpec)
+
+test_StrongPathInstance :: IO TestTree
+test_StrongPathInstance = testSpec "StrongPath.Instance" $ do
+  it "Hashable returns hash of underlying filepath" $ do
+    let rawPath = "/abPath/dir/"
+    path <- parseAbsDir rawPath
+    hash rawPath `shouldBe` hash path

--- a/test/StrongPath/InstanceTest.hs
+++ b/test/StrongPath/InstanceTest.hs
@@ -8,7 +8,12 @@ import Test.Tasty.Hspec (testSpec)
 
 test_StrongPathInstance :: IO TestTree
 test_StrongPathInstance = testSpec "StrongPath.Instance" $ do
-  it "Hashable returns hash of underlying filepath" $ do
-    let rawPath = "relPath/dir/"
-    path <- parseRelDir rawPath
-    hash rawPath `shouldBe` hash path
+  it "Different paths have different hash" $ do
+    aPath <- parseRelDir "a"
+    bPath <- parseRelDir "b"
+    hash aPath `shouldNotBe` hash bPath
+  it "Concatenated Paths have same hash as Path directly constructed from parts" $ do
+    aPath <- parseRelDir "a"
+    bPath <- parseRelDir "b"
+    abPath <- parseRelDir "a/b"
+    hash (aPath </> bPath) `shouldBe` hash abPath


### PR DESCRIPTION
Hey @Martinsos 

I saw your call for participation in [Issue 300](https://haskellweekly.news/issue/300.html) of the Haskell weekly newsletter.

I went with your suggestion to implement the `hashable` instance by using the `toFilePath` function to resolve Issue #43.
Please let me know if this is what you had in mind or if anything should be added or changed in this PR

Kind regards.

