### PR TITLE
Make Path an instance of Ord

### DIFF
--- a/src/StrongPath/Instances.hs
+++ b/src/StrongPath/Instances.hs
@@ -7,7 +7,7 @@ import StrongPath.FilePath
 import StrongPath.Types
 
 -- Hashable instance for Path declared here, as an orphaned instance, instead of
--- in StronPath.Internal to avoid cyclic dependency between StrongPath.FilePath
+-- in StrongPath.Internal to avoid cyclic dependency between StrongPath.FilePath
 -- and StrongPath.Internal. (This cycle would arise due to the use of
 -- `toFilePath` from FilePath in the instance declaration and the dependency of
 -- the FilePath module on the types from the Internal module)
@@ -18,3 +18,7 @@ import StrongPath.Types
 -- they are different paths.
 instance Hashable (Path s b t) where
   hashWithSalt salt = hashWithSalt salt . toFilePath
+
+-- Paths can be compared
+instance Ord (Path s b t) where
+  compare p1 p2 = compare (toFilePath p1) (toFilePath p2)

--- a/test/StrongPath/InstanceTest.hs
+++ b/test/StrongPath/InstanceTest.hs
@@ -1,6 +1,7 @@
 module StrongPath.InstanceTest where
 
 import Data.Hashable
+import Data.List (sort)
 import StrongPath
 import Test.Hspec
 import Test.Tasty (TestTree)
@@ -17,3 +18,13 @@ test_StrongPathInstance = testSpec "StrongPath.Instance" $ do
     bPath <- parseRelDir "b"
     abPath <- parseRelDir "a/b"
     hash (aPath </> bPath) `shouldBe` hash abPath
+  it "Paths can be compared" $ do
+    aPath <- parseRelDir "a"
+    bPath <- parseRelDir "b"
+    aPath < bPath `shouldBe` True
+    aPath > bPath `shouldBe` False
+  it "Path can be sorted because they can be compared" $ do
+    aPath <- parseRelDir "a"
+    bPath <- parseRelDir "b"
+    abPath <- parseRelDir "a/b"
+    sort [bPath, abPath, aPath] `shouldBe` [aPath, abPath, bPath]


### PR DESCRIPTION
This makes it possible to sort paths, and means paths can now be used as a key in Data.Map and in Data.Set